### PR TITLE
Fixed window spliting axis bug and restructured code to show intent more clearly

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,36 +1,41 @@
-use swayipc::reply::{Event, Node, NodeLayout, NodeType, WindowChange};
+use swayipc::reply::{Event, NodeLayout, NodeType, WindowChange};
 use swayipc::{Connection, EventType};
 
-fn switch_splitting(conn: &mut Connection, focused_node: Node) -> Result<(), String> {
-    // get info from parent node which unfortunately requires us to call get_tree
+fn switch_splitting(conn: &mut Connection) -> Result<(), String> {
+    // get info from focused node and parent node which unfortunately requires us to call get_tree
     let tree = conn.get_tree().unwrap();
+    let focused_node = tree
+        .find_focused_as_ref(|n| n.focused)
+        .ok_or("Could not find the focused node")?;
+
+    {
+        // get info from the focused child node
+        let is_stacked = focused_node.layout == NodeLayout::Stacked;
+        let is_tabbed = focused_node.layout == NodeLayout::Tabbed;
+        let is_floating = focused_node.node_type == NodeType::FloatingCon;
+        let is_full_screen = focused_node.percent.unwrap_or(1.0) > 1.0;
+        if is_floating || is_full_screen || is_stacked || is_tabbed {
+            return Ok(());
+        }
+    }
+
+    let new_layout = if focused_node.rect.height > focused_node.rect.width {
+        NodeLayout::SplitV
+    } else {
+        NodeLayout::SplitH
+    };
     let parent = tree
         .find_focused_as_ref(|n| n.nodes.iter().any(|n| n.focused))
         .ok_or("No parent")?;
-    let is_stacked = parent.layout == NodeLayout::Stacked;
-    let is_tabbed = parent.layout == NodeLayout::Tabbed;
-
-    // get info from the focused child node
-    let is_floating = focused_node.node_type == NodeType::FloatingCon;
-    let is_full_screen = focused_node.percent.unwrap_or(1.0) > 1.0;
-
-    if !is_floating && !is_full_screen && !is_stacked && !is_tabbed {
-        let new_layout = if focused_node.rect.height > focused_node.rect.width {
-            NodeLayout::SplitV
-        } else {
-            NodeLayout::SplitH
-        };
-
-        if new_layout != parent.layout {
-            let cmd = match new_layout {
-                NodeLayout::SplitV => "splitv",
-                NodeLayout::SplitH => "splith",
-                _ => "nop",
-            };
-            conn.run_command(cmd).unwrap();
-        };
+    if new_layout == parent.layout {
+        return Ok(());
+    }
+    let cmd = match new_layout {
+        NodeLayout::SplitV => "splitv",
+        NodeLayout::SplitH => "splith",
+        _ => "nop",
     };
-
+    conn.run_command(cmd).unwrap();
     Ok(())
 }
 
@@ -44,7 +49,12 @@ fn main() -> Result<(), std::io::Error> {
         match event.unwrap() {
             Event::Window(e) => match e.change {
                 WindowChange::Focus => {
-                    if let Err(err) = switch_splitting(&mut conn, e.container) {
+                    //we can not use the e.container because the data is stale
+                    //if we compare that node data with the node given from get_tree() after we
+                    //delete a node we find that the e.container.rect.height and e.container.rect.width are stale
+                    //and therefore we make the wrong decision on which layout our next window
+                    //should be
+                    if let Err(err) = switch_splitting(&mut conn) {
                         println!("err: {}", err);
                     }
                 }


### PR DESCRIPTION
Fixed a bug where after you close a window the following focus event triggered reports the wrong width and height for that window. This leads to the wrong decision on `splitv`or `splith` and the next window ends up spliting along the wrong axis.

The fix involves just ignoring the node data received from the event and fetching it ourselves via `get_tree()`.

I also restructured the code to something I find more readable, less nesting, early return etc. Let me if you'd like me to remove these changes.

I had inspiration from the following project when I was trying to locate the bug.
This project also runs a lookup with the equivalent `get_tree()` to get the `focuses_node`. 
https://github.com/nwg-piotr/autotiling/blob/58de027b790d56515b202d4a26abe7fda9cd9dbc/autotiling/main.py