### PR TITLE
Add a link for the Arch Community repo package to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,6 @@ For more info run `autotiling-rs --help`.
 
 ## Installation
 
-Arch Linux: Found on the AUR as [autotiling-rs-git](https://aur.archlinux.org/packages/autotiling-rs-git).
+Arch Linux: [autotiling-rs](https://archlinux.org/packages/?q=autotiling-rs)
+
+Arch Linux (AUR): [autotiling-rs-git](https://aur.archlinux.org/packages/autotiling-rs-git).


### PR DESCRIPTION
Since `Aug 23, 2022` this project was packaged in the Arch Community Repository.

https://github.com/archlinux/svntogit-community/commit/5ae361a199bc9120b33e059b3d8b241f4af76949