### PR TITLE
Add a link for Nix package to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,5 @@ For more info run `autotiling-rs --help`.
 Arch Linux: [autotiling-rs](https://archlinux.org/packages/?q=autotiling-rs)
 
 Arch Linux (AUR): [autotiling-rs-git](https://aur.archlinux.org/packages/autotiling-rs-git).
+
+Nix: [autotiling-rs](https://search.nixos.org/packages?channel=unstable&show=autotiling-rs&from=0&size=50&sort=relevance&type=packages&query=autotiling-rs)


### PR DESCRIPTION
Saw #13 and figured I'd follow suite for Nix.

Was added as of 2022-07-23. See https://github.com/NixOS/nixpkgs/commit/83e1754b23c3f9561a0753fc3a9d84d0549a0f8a