### PR TITLE
add Gentoo GURU to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,5 @@ Arch Linux: [autotiling-rs](https://archlinux.org/packages/?q=autotiling-rs)
 Arch Linux (AUR): [autotiling-rs-git](https://aur.archlinux.org/packages/autotiling-rs-git).
 
 Nix: [autotiling-rs](https://search.nixos.org/packages?channel=unstable&show=autotiling-rs&from=0&size=50&sort=relevance&type=packages&query=autotiling-rs)
+
+Gentoo GURU: [autotiling-rs](https://gpo.zugaina.org/gui-apps/autotiling-rs)


### PR DESCRIPTION
Hello, thanks for the great tool. I added this package to Gentoo GURU as it wasn't available. I plan on maintaining it. For futher reference, here is the [commit](https://gitweb.gentoo.org/repo/proj/guru.git/commit/?id=355a5b56b5e3564930e43a30839721a13c6fb29b).

This PR just has a link to the package added to the readme.

Thanks again.